### PR TITLE
xsd:poNumber cannot contain child node

### DIFF
--- a/lib/payment_drivers/authorize_net_driver.php
+++ b/lib/payment_drivers/authorize_net_driver.php
@@ -331,9 +331,7 @@ class Authorize_Net_Driver extends Payment_Driver
 
 		if(isset($params['po_num']))
 		{
-			$fields['poNumber'] = array(
-				'poNumber' => $params['po_num']
-			);		
+			$fields['poNumber'] = $params['po_num'];		
 		}
 		
 		$fields['customer'] = $this->_build_customer_fields($params);


### PR DESCRIPTION
While returning array for poNumber it appends a child node under <poNumber></poNumber>
The transaction fails with following error.
The element 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:poNumber' cannot contain child element 'AnetApi/xml/v1/schema/AnetApiSchema.xsd:poNumber' because the parent element's content model is text only.
