### PR TITLE
ewayCVN is required by default

### DIFF
--- a/lib/payment_drivers/eway_driver.php
+++ b/lib/payment_drivers/eway_driver.php
@@ -61,6 +61,7 @@ class Eway_Driver Extends Payment_Driver
 						'email',
 						'cc_number',
 						'cc_exp',
+						'cc_code',
 						'street',
 						'postal_code',
 						'desc'
@@ -71,6 +72,7 @@ class Eway_Driver Extends Payment_Driver
 						'last_name' => 'ewayCardHoldersName&ewayCustomerLastName',
 						'cc_number' => 'ewayCardNumber',
 						'cc_exp' => 'ewayCardExpiryMonth,ewayCardExpiryYear',
+						'cc_code' => 'ewayCVN',
 						'email' => 'ewayCustomerEmail',
 						'street' => 'ewayCustomerAddress',
 						'postal_code' => 'ewayCustomerPostcode',


### PR DESCRIPTION
Recent changes to the eway api now require that the credit card CVN to be required by default.
