### PR TITLE
Allow setting order number for Beanstream payments

### DIFF
--- a/lib/payment_drivers/beanstream_driver.php
+++ b/lib/payment_drivers/beanstream_driver.php
@@ -189,6 +189,7 @@ class Beanstream_Driver
 			}
 			
 			if($method === 'Q')
+			if($method === 'Q' OR $method === 'P')
 			{
 				$request['trnOrderNumber'] = $params['identifier'];
 			}


### PR DESCRIPTION
Beanstream's documentation recommends setting an order number for payments, but it seems in the current version you can't set it, it least not for payment api calls.
