### PR TITLE
Update config/payments.php

### DIFF
--- a/config/payments.php
+++ b/config/payments.php
@@ -16,7 +16,7 @@ $config['force_secure_connection'] = FALSE;
 
 /**
  * Sets the language to be used
-/
+ */
 $config['language'] = 'english';
 
 /**


### PR DESCRIPTION
Seems to be a missing comment ending

$config['language'] = 'english'; was commented out as a result.
